### PR TITLE
EMTF BIG emulator update - attempt #2, June 7 [cms-l1t-offline/cmssw#542]

### DIFF
--- a/L1TMuon/interface/EMTFHit.h
+++ b/L1TMuon/interface/EMTFHit.h
@@ -22,17 +22,17 @@ namespace l1t {
   public:
 
     EMTFHit() :
-        endcap(-99), station(-99), ring(-99), sector(-99), sector_idx(-99), subsector(-99),
-        chamber(-99), csc_ID(-99), csc_nID(-99), roll(-99), neighbor(-99), mpc_link(-99),
-        pc_sector(-99), pc_station(-99), pc_chamber(-99), pc_segment(-99),
-        wire(-99), strip(-99), strip_hi(-99), strip_low(-99), track_num(-99), quality(-99),
-        pattern(-99), bend(-99), valid(-99), sync_err(-99), bc0(-99), bx(-99), stub_num(-99),
-        phi_fp(-99), theta_fp(-99), phzvl(-99), ph_hit(-99), zone_hit(-99), zone_code(-99),
-        fs_segment(-99), fs_zone_code(-99), bt_station(-99), bt_segment(-99),
-        phi_loc(-99), phi_glob(-99), theta(-99), eta(-99),
-        phi_sim(-99), theta_sim(-99), eta_sim(-99),
-        is_CSC(-99), is_RPC(-99), is_GEM(-99), subsystem(-99)
-        {};
+    endcap(-99), station(-99), ring(-99), sector(-99), sector_RPC(-99), sector_idx(-99), 
+      subsector(-99), subsector_RPC(-99), chamber(-99), csc_ID(-99), csc_nID(-99), roll(-99), 
+      neighbor(-99), mpc_link(-99), pc_sector(-99), pc_station(-99), pc_chamber(-99), pc_segment(-99),
+      wire(-99), strip(-99), strip_hi(-99), strip_low(-99), track_num(-99), quality(-99),
+      pattern(-99), bend(-99), valid(-99), sync_err(-99), bc0(-99), bx(-99), stub_num(-99),
+      phi_fp(-99), theta_fp(-99), phzvl(-99), ph_hit(-99), zone_hit(-99), zone_code(-99),
+      fs_segment(-99), fs_zone_code(-99), bt_station(-99), bt_segment(-99),
+      phi_loc(-99), phi_glob(-99), theta(-99), eta(-99),
+      phi_sim(-99), theta_sim(-99), eta_sim(-99),
+      is_CSC(-99), is_RPC(-99), is_GEM(-99), subsystem(-99)
+      {};
 
     virtual ~EMTFHit() {};
 
@@ -70,8 +70,10 @@ namespace l1t {
     void set_station      (int  bits) { station      = bits; }
     void set_ring         (int  bits) { ring         = bits; }
     void set_sector       (int  bits) { sector       = bits; }
+    void set_sector_RPC   (int  bits) { sector_RPC   = bits; }
     void set_sector_idx   (int  bits) { sector_idx   = bits; }
     void set_subsector    (int  bits) { subsector    = bits; }
+    void set_subsector_RPC(int  bits) { subsector_RPC= bits; }
     void set_chamber      (int  bits) { chamber      = bits; }
     void set_csc_ID       (int  bits) { csc_ID       = bits; }
     void set_csc_nID      (int  bits) { csc_nID      = bits; }
@@ -121,8 +123,10 @@ namespace l1t {
     int   Station      ()  const { return station     ; }
     int   Ring         ()  const { return ring        ; }
     int   Sector       ()  const { return sector      ; }
+    int   Sector_RPC   ()  const { return sector_RPC  ; }
     int   Sector_idx   ()  const { return sector_idx  ; }
     int   Subsector    ()  const { return subsector   ; }
+    int   Subsector_RPC()  const { return subsector_RPC; }
     int   Chamber      ()  const { return chamber     ; }
     int   CSC_ID       ()  const { return csc_ID      ; }
     int   CSC_nID      ()  const { return csc_nID     ; }
@@ -181,10 +185,12 @@ namespace l1t {
     int   endcap      ; //    +/-1.  For ME+ and ME-.
     int   station     ; //  1 -  4.
     int   ring        ; //  1 -  4.  ME1/1a is denoted as "Ring 4".  Should check dependence on input CSCDetId convention. - AWB 02.03.17
-    int   sector      ; //  1 -  6.
+    int   sector      ; //  1 -  6.  CSC / EMTF sector convention: sector 1 starts at 15 degrees
+    int   sector_RPC  ; //  1 -  6.  RPC sector convention (in CMSSW): sector 1 starts at -5 degrees
     int   sector_idx  ; //  0 - 11.  0 - 5 for ME+, 6 - 11 for ME-.  For neighbor hits, set by EMTF sector that received it.
-    int   subsector   ; //  0 -  6.  In CSCs, 1 or 2 for ME1, 0 for ME2/3/4.  In RPCs, 1 - 6.
-    int   chamber     ; //  1 - 36.  For CSCs only.  0 for RPCs.
+    int   subsector   ; //  0 -  6.  In CSCs, 1 or 2 for ME1, 0 for ME2/3/4.  In RPCs, 1 - 6, where 1 is first chamber in EMTF sector.
+    int   subsector_RPC; // 0 -  6.  RPC sector convention (in CMSSW): subsector 3 is the first chamber in the EMTF sector.
+    int   chamber     ; //  1 - 36.  Chamber 1 starts at -5 degrees.
     int   csc_ID      ; //  1 -  9.  For CSCs only.
     int   csc_nID     ; //  1 - 15.  For CSCs only.  Neighbors 10 - 15, 12 not filled.
     int   roll        ; //  1 -  3.  For RPCs only, sub-division of ring. (Range? - AWB 02.03.17)

--- a/L1TMuon/interface/EMTFHit.h
+++ b/L1TMuon/interface/EMTFHit.h
@@ -29,8 +29,8 @@ namespace l1t {
       pattern(-99), bend(-99), valid(-99), sync_err(-99), bc0(-99), bx(-99), stub_num(-99),
       phi_fp(-99), theta_fp(-99), phzvl(-99), ph_hit(-99), zone_hit(-99), zone_code(-99),
       fs_segment(-99), fs_zone_code(-99), bt_station(-99), bt_segment(-99),
-      phi_loc(-99), phi_glob(-99), theta(-99), eta(-99),
-      phi_sim(-99), theta_sim(-99), eta_sim(-99),
+      phi_loc(-99), phi_glob(-999), theta(-99), eta(-99),
+      phi_sim(-999), theta_sim(-99), eta_sim(-99),
       is_CSC(-99), is_RPC(-99), is_GEM(-99), subsystem(-99)
       {};
 

--- a/L1TMuon/interface/EMTFTrack.h
+++ b/L1TMuon/interface/EMTFTrack.h
@@ -41,8 +41,8 @@ namespace l1t {
       mode(-99), mode_CSC(0), mode_RPC(0), mode_neighbor(0), mode_inv(-99),
       rank(-99), winner(-99), charge(-99), bx(-99), first_bx(-99), second_bx(-99),
       pt(-99), pt_XML(-99), zone(-99), ph_num(-99), ph_q(-99),
-      theta_fp(-99), theta(-99), eta(-99), phi_fp(-99), phi_loc(-99), phi_glob(-99),
-      gmt_pt(-99), gmt_phi(-99), gmt_eta(-99), gmt_quality(-99), gmt_charge(-99), gmt_charge_valid(-99),
+      theta_fp(-99), theta(-99), eta(-99), phi_fp(-99), phi_loc(-99), phi_glob(-999),
+      gmt_pt(-99), gmt_phi(-999), gmt_eta(-999), gmt_quality(-99), gmt_charge(-99), gmt_charge_valid(-99),
       track_num(-99), numHits(-99) 
       {};
     

--- a/L1TMuon/interface/EMTFTrack.h
+++ b/L1TMuon/interface/EMTFTrack.h
@@ -18,6 +18,7 @@ namespace l1t {
     uint64_t address;
     uint16_t mode;
     uint16_t theta;
+    uint16_t st1_ring2;
     uint16_t eta;
     uint16_t delta_ph [6]; // index: 0=12, 1=13, 2=14, 3=23, 4=24, 5=34
     uint16_t delta_th [6]; // ^

--- a/L1TMuon/interface/RegionalMuonCand.h
+++ b/L1TMuon/interface/RegionalMuonCand.h
@@ -12,6 +12,11 @@ class RegionalMuonCand {
     enum bmtfAddress {
         kWheelSide=0, kWheelNum=1, kStat1=2, kStat2=3, kStat3=4, kStat4=5, kSegSelStat1=6, kSegSelStat2=7, kSegSelStat3=8, kSegSelStat4=9, kNumBmtfSubAddr=10
     };
+    /// Enum to identify the individual parts of the OMTF track address
+    /// Update kNumEmtfSubAddr if you add additional enums
+    enum omtfAddress {
+	kLayers=0, kZero=1, kWeight=2, kNumOmtfSubAddr=3
+    };
     /// Enum to identify the individual parts of the EMTF track address
     /// Update kNumEmtfSubAddr if you add additional enums
     enum emtfAddress {
@@ -62,6 +67,10 @@ class RegionalMuonCand {
     void setTrackSubAddress(bmtfAddress subAddress, int value) {
         m_trackAddress[subAddress] = value;
     }
+    /// Set a part of the muon candidates track address; specialised for OMTF
+    void setTrackSubAddress(omtfAddress subAddress, int value) {
+        m_trackAddress[subAddress] = value;
+    }
     /// Set a part of the muon candidates track address; specialised for EMTF
     void setTrackSubAddress(emtfAddress subAddress, int value) {
         m_trackAddress[subAddress] = value;
@@ -104,6 +113,10 @@ class RegionalMuonCand {
     }
     /// Get part of track address (identifies track primitives used for reconstruction)
     int trackSubAddress(bmtfAddress subAddress) const {
+        return m_trackAddress.at(subAddress);
+    }
+    /// Get part of track address (identifies track primitives used for reconstruction)
+    int trackSubAddress(omtfAddress subAddress) const {
         return m_trackAddress.at(subAddress);
     }
     /// Get part of track address (identifies track primitives used for reconstruction)

--- a/L1TMuon/src/EMTFHit.cc
+++ b/L1TMuon/src/EMTFHit.cc
@@ -3,10 +3,12 @@
 namespace l1t {
 
   CSCDetId EMTFHit::CreateCSCDetId() const {
-    return CSCDetId( (endcap == 1) ? 1 : 2, station,    // For now, leave "layer" unfilled, defaults to 0.
-         (ring == 4) ? 1 : ring, chamber ); // Not sure if this is correct, or what "layer" does. - AWB 27.04.16
+    return CSCDetId( (endcap == 1) ? 1 : 2, station,
+		     (ring == 4) ? 1 : ring, chamber, 0 ); 
+    // Layer always filled as 0 (indicates "whole chamber")
+    // See http://cmslxr.fnal.gov/source/L1Trigger/CSCTriggerPrimitives/src/CSCTriggerPrimitivesBuilder.cc#0198
   }
-
+  
   // // Not yet implemented - AWB 15.03.17
   // RPCDetId EMTFHit::CreateRPCDetId() const {
   //   return RPCDetId( endcap, ring, station, sector, rpc_layer, subsector, roll );
@@ -14,15 +16,16 @@ namespace l1t {
 
   CSCCorrelatedLCTDigi EMTFHit::CreateCSCCorrelatedLCTDigi() const {
     return CSCCorrelatedLCTDigi( 1, valid, quality, wire, strip,
-         pattern, (bend == 1) ? 1 : 0,
-         bx + 6, 0, 0, sync_err, csc_ID );
-    // Unsure of how to fill "trknmb" or "bx0" - for now filling with 1 and 0. - AWB 27.04.16
-    // Appear to be unused in the emulator code. mpclink = 0 (after bx) indicates unsorted.
+				 pattern, (bend == 1) ? 1 : 0,
+				 bx + 6, 0, 0, sync_err, csc_ID );
+    // Filling "trknmb" with 1 and "bx0" with 0 (as in MC).
+    // May consider filling "trknmb" with 2 for 2nd LCT in the same chamber. - AWB 24.05.17
+    // trknmb and bx0 are unused in the EMTF emulator code. mpclink = 0 (after bx) indicates unsorted.
   }
-
+  
   // // Not yet implemented - AWB 15.03.17
   // RPCDigi EMTFHit::CreateRPCDigi() const {
   //   return RPCDigi( (strip_hi + strip_lo) / 2, bx + 6 );
   // }
-
+  
 } // End namespace l1t


### PR DESCRIPTION
This applies all the commits in https://github.com/cms-l1t-offline/cmssw/pull/542 up to June 7. The branch is https://github.com/abrinke1/cmssw/tree/EMTF_May_2017_merge .

This works in CMSSW_9_2_0 release.

The original commits are extracted by:

```sh
### Extract
git format-patch -1 a1a34ee . --stdout > commit-a1a34ee.patch
git format-patch -1 9041288 . --stdout > commit-9041288.patch
git format-patch -1 f24962c . --stdout > commit-f24962c.patch
git format-patch -1 3089073 . --stdout > commit-3089073.patch
git format-patch -1 f6b1b97 . --stdout > commit-f6b1b97.patch

### Apply
git am -p2 $ORI/commit-a1a34ee.patch 
git am -p2 $ORI/commit-9041288.patch
git am -p2 $ORI/commit-f24962c.patch
git am -p2 $ORI/commit-3089073.patch
git am -p2 $ORI/commit-f6b1b97.patch
```

The HEAD at the time of this PR is https://github.com/abrinke1/cmssw/tree/bfab85e0168c4c1ea47f3d2d6aa48233f5ab1008
