### PR TITLE
uGMT input packer reactivation and upgrade [cms-sw/cmssw#637]

### DIFF
--- a/L1TMuon/interface/RegionalMuonCand.h
+++ b/L1TMuon/interface/RegionalMuonCand.h
@@ -27,9 +27,7 @@ class RegionalMuonCand {
     explicit RegionalMuonCand(uint64_t dataword);
 
     RegionalMuonCand() :
-      m_hwPt(0), m_hwPhi(0), m_hwEta(0), m_hwHF(false), m_hwSign(0), m_hwSignValid(0), m_hwQuality(0),
-      m_trackAddress({{kWheelSide, 0}, {kWheelNum, 0}, {kStat1, 0}, {kStat2, 0}, {kStat3, 0}, {kStat4, 0}, {kSegSelStat1, 0}, {kSegSelStat2, 0}, {kSegSelStat3, 0}, {kSegSelStat4, 0}}),
-      m_dataword(0)
+      m_hwPt(0), m_hwPhi(0), m_hwEta(0), m_hwHF(false), m_hwSign(0), m_hwSignValid(0), m_hwQuality(0), m_trackAddress(), m_dataword(0)
       {
         setTFIdentifiers(0, bmtf);
       };


### PR DESCRIPTION
This PR brings me synchronized with the cms-l1t-offline:l1t-integration-CMSSW_9_4_0_pre3 branch. 

The original commits are extracted and applied as follows:

```
## Extract
git format-patch -1 cedfbeec958 . --stdout > commit-cedfbeec958.patch

## Apply
git am -p2 $ORI/commit-cedfbeec958.patch
```

The remote HEAD at the time of this PR is https://github.com/cms-l1t-offline/cmssw/commit/2ccff46b516d2615d75c946171f944de966d44dd